### PR TITLE
docs: fix dev instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ A simple tool to track the time spent on activities with campers.
 ```bash
 corepack enable # one-time, so pnpm is picked up from the packageManager field
 pnpm install
-pnpm dev # runs the dev API server at http://localhost:8787
-pnpm live-server # runs a local web server at http://localhost:8080
+pnpm start # runs the Vite dev server at http://localhost:8787
 ```
 
 > [!TIP]


### PR DESCRIPTION
## Summary
- Drop the broken `pnpm live-server` step and point dev instructions at `pnpm start` (Vite on 8787).
- The `live-server` flow has been broken since `web/index.ts` was renamed to `.tsx` (commit 06237e8, June 2025) — live-server can't transpile, so `/web/index.js` 404s. Vite handles `.tsx` transparently.

The unused `live-server` script + devDependency are still in `package.json`; leaving that cleanup for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)