### PR TITLE
Move GOOGLE_SHEET_ID from secret to vars

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,7 +16,7 @@
     "directory": "./web/",
     "not_found_handling": "single-page-application",
     "run_worker_first": ["/activities/*", "/docs/*"]
-  }
+  },
   /**
    * Smart Placement
    * Docs: https://developers.cloudflare.com/workers/configuration/smart-placement/#smart-placement
@@ -34,7 +34,7 @@
    * Environment Variables
    * https://developers.cloudflare.com/workers/wrangler/configuration/#environment-variables
    */
-  // "vars": { "MY_VARIABLE": "production_value" },
+  "vars": { "GOOGLE_SHEET_ID": "1HjCYWtonxlE1BjRlFCquFyu4_r9S9dKQmSi0ZBzNYmg" },
   /**
    * Note: Use secrets to store sensitive data.
    * https://developers.cloudflare.com/workers/configuration/secrets/


### PR DESCRIPTION
## Summary
- `GOOGLE_SHEET_ID` isn't actually sensitive — move it into `wrangler.jsonc` under `vars` so it's visible in source.
- `.dev.vars` still overrides it for local development.

## Follow-up
After deploy, run `wrangler secret delete GOOGLE_SHEET_ID` so the existing encrypted secret stops shadowing the new var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)