### PR TITLE
Add activity delete

### DIFF
--- a/src/endpoints/activityDelete.ts
+++ b/src/endpoints/activityDelete.ts
@@ -17,17 +17,6 @@ export class ActivityDelete extends OpenAPIRoute {
       "204": {
         description: "Returns no content",
       },
-      "404": {
-        description: "Returns a 404 status code if the id is not found",
-        content: {
-          "application/json": {
-            schema: z.object({
-              success: z.boolean(),
-              message: z.string(),
-            }),
-          },
-        },
-      },
     },
   };
 
@@ -41,11 +30,9 @@ export class ActivityDelete extends OpenAPIRoute {
 
     const rows = await sheet.getRows();
     const row = rows.find((r) => r.get("Id") === id);
-    if (!row) {
-      return c.json({ success: false, message: `Activity with id ${id} not found` }, 404);
+    if (row) {
+      await sheet.clearRows({ start: row.rowNumber, end: row.rowNumber });
     }
-
-    await sheet.clearRows({ start: row.rowNumber, end: row.rowNumber });
 
     return new Response(null, { status: 204 });
   }

--- a/src/endpoints/activityDelete.ts
+++ b/src/endpoints/activityDelete.ts
@@ -1,0 +1,55 @@
+import { OpenAPIRoute, Uuid } from "chanfana";
+import { z } from "zod";
+import type { Context } from "hono";
+
+import { getSheetFromEnv } from "../sheets";
+
+export class ActivityDelete extends OpenAPIRoute {
+  schema = {
+    tags: ["Activities"],
+    summary: "Delete an Activity by id. Leaves a blank row in the spreadsheet.",
+    request: {
+      params: z.object({
+        id: Uuid(),
+      }),
+    },
+    responses: {
+      "204": {
+        description: "Returns no content",
+      },
+      "404": {
+        description: "Returns a 404 status code if the id is not found",
+        content: {
+          "application/json": {
+            schema: z.object({
+              success: z.boolean(),
+              message: z.string(),
+            }),
+          },
+        },
+      },
+    },
+  };
+
+  async handle(c: Context) {
+    const data = await this.getValidatedData<typeof this.schema>();
+
+    const id = data.params.id;
+
+    const sheet = await getSheetFromEnv(c.env);
+    await sheet.loadHeaderRow();
+
+    const rows = await sheet.getRows();
+    const row = rows.find((r) => r.get("Id") === id);
+    if (!row) {
+      return c.json({ success: false, message: `Activity with id ${id} not found` }, 404);
+    }
+
+    for (const header of sheet.headerValues) {
+      row.set(header, null);
+    }
+    await row.save();
+
+    return new Response(null, { status: 204 });
+  }
+}

--- a/src/endpoints/activityDelete.ts
+++ b/src/endpoints/activityDelete.ts
@@ -46,7 +46,7 @@ export class ActivityDelete extends OpenAPIRoute {
     }
 
     for (const header of sheet.headerValues) {
-      row.set(header, null);
+      row.set(header, "");
     }
     await row.save();
 

--- a/src/endpoints/activityDelete.ts
+++ b/src/endpoints/activityDelete.ts
@@ -45,10 +45,7 @@ export class ActivityDelete extends OpenAPIRoute {
       return c.json({ success: false, message: `Activity with id ${id} not found` }, 404);
     }
 
-    for (const header of sheet.headerValues) {
-      row.set(header, "");
-    }
-    await row.save();
+    await row.delete();
 
     return new Response(null, { status: 204 });
   }

--- a/src/endpoints/activityDelete.ts
+++ b/src/endpoints/activityDelete.ts
@@ -45,7 +45,7 @@ export class ActivityDelete extends OpenAPIRoute {
       return c.json({ success: false, message: `Activity with id ${id} not found` }, 404);
     }
 
-    await row.delete();
+    await sheet.clearRows({ start: row.rowNumber, end: row.rowNumber });
 
     return new Response(null, { status: 204 });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 
 import { ActivityUpsert } from "./endpoints/activityUpsert";
+import { ActivityDelete } from "./endpoints/activityDelete";
 
 // Start a Hono app
 const app = new Hono();
@@ -16,6 +17,7 @@ openapi.use(cors());
 
 // Register OpenAPI endpoints
 openapi.put("/activities/:id", ActivityUpsert);
+openapi.delete("/activities/:id", ActivityDelete);
 
 // Export the Hono app
 export default app;

--- a/web/components/EditActivityModal.tsx
+++ b/web/components/EditActivityModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "preact/hooks";
 
 import { getActivityFromIndexedDB } from "@/data/database";
 import { upsertActivity } from "@/data/upsertActivity";
+import { deleteActivity } from "@/data/deleteActivity";
 
 import { Modal } from "@/components/Modal";
 import { Label, LabelLike } from "@/components/Label";
@@ -253,6 +254,26 @@ export const EditActivityModal = ({
 
           <Button type="submit" disabled={!activity.value.camperName || !activity.value.therapistName}>
             Save
+          </Button>
+
+          <Button
+            type="button"
+            variant="danger"
+            onClick={async () => {
+              if (!self.confirm("Delete this activity? This cannot be undone.")) return;
+              setControlsDisabled(true);
+              try {
+                await deleteActivity({ database }, activityId);
+              } catch (error) {
+                setControlsDisabled(false);
+                console.warn("Failed to delete activity", String(error));
+                self.alert("Failed to delete activity. Please try again.");
+                return;
+              }
+              onClose();
+            }}
+          >
+            Delete
           </Button>
         </fieldset>
       </form>

--- a/web/data/database.ts
+++ b/web/data/database.ts
@@ -39,6 +39,18 @@ export const upsertActivityInIndexedDB = async (database: IDBDatabase, activity:
   });
 };
 
+export const deleteActivityFromIndexedDB = async (database: IDBDatabase, id: string) => {
+  return new Promise<void>((resolve, reject) => {
+    const activitiesStore = database.transaction("activities", "readwrite").objectStore("activities");
+    const request = activitiesStore.delete(id);
+    request.onsuccess = () => {
+      database.dispatchEvent(new Event("activities:changed"));
+      return resolve();
+    };
+    request.onerror = () => reject(request.error);
+  });
+};
+
 export const getActivityFromIndexedDB = async (database: IDBDatabase, id: string) => {
   return new Promise<Activity>((resolve, reject) => {
     const activitiesStore = database.transaction("activities", "readonly").objectStore("activities");

--- a/web/data/deleteActivity.ts
+++ b/web/data/deleteActivity.ts
@@ -2,13 +2,9 @@ import { apiUrl } from "@/data/apiUrl";
 import { assert } from "@/assert";
 import { deleteActivityFromIndexedDB } from "@/data/database";
 
-/**
- * Deletes the activity remotely and then removes it from IndexedDB.
- * If the remote returns 404, treat the activity as already gone and still remove it locally.
- */
 export const deleteActivity = async ({ database }: { database: IDBDatabase }, id: string) => {
   const res = await fetch(apiUrl(`/activities/${id}`), { method: "DELETE" });
-  assert(res.ok || res.status === 404, `Received non-2xx response from DELETE activity: ${res.status}`);
+  assert(res.ok, `Received non-2xx response from DELETE activity: ${res.status}`);
 
   await deleteActivityFromIndexedDB(database, id);
 };

--- a/web/data/deleteActivity.ts
+++ b/web/data/deleteActivity.ts
@@ -1,0 +1,14 @@
+import { apiUrl } from "@/data/apiUrl";
+import { assert } from "@/assert";
+import { deleteActivityFromIndexedDB } from "@/data/database";
+
+/**
+ * Deletes the activity remotely and then removes it from IndexedDB.
+ * If the remote returns 404, treat the activity as already gone and still remove it locally.
+ */
+export const deleteActivity = async ({ database }: { database: IDBDatabase }, id: string) => {
+  const res = await fetch(apiUrl(`/activities/${id}`), { method: "DELETE" });
+  assert(res.ok || res.status === 404, `Received non-2xx response from DELETE activity: ${res.status}`);
+
+  await deleteActivityFromIndexedDB(database, id);
+};


### PR DESCRIPTION
## Summary
- Adds `DELETE /activities/:id` endpoint that clears all cells in the matching Google Sheet row (leaves a blank row)
- Adds `deleteActivityFromIndexedDB` to remove the activity from local IndexedDB
- Adds a Delete button (danger variant) to the EditActivityModal with a confirmation dialog

## Test plan
- Open History, click an activity, verify the Delete button appears
- Click Delete, confirm in the dialog, verify the activity disappears from the list
- Check the Google Sheet to verify the row is cleared (blank row remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)