### PR TITLE
Reduce session length warning limit to 2 hours

### DIFF
--- a/web/data/getDatetimeWarning.ts
+++ b/web/data/getDatetimeWarning.ts
@@ -17,8 +17,8 @@ export const getDatetimeWarning = (start: Date | null, end: Date | null) => {
     return "Activity duration is less than 1 minute";
   }
 
-  if (end.getTime() - start.getTime() > 1000 * 60 * 60 * 10) {
-    return "Activity is longer than 10 hours";
+  if (end.getTime() - start.getTime() > 1000 * 60 * 60 * 2) {
+    return "Activity is longer than 2 hours";
   }
 
   return;


### PR DESCRIPTION
## Summary
- Warn when an activity is longer than 2 hours instead of 10. Exactly 2 hours is still fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)