### PR TITLE
Confirm save on activity warning; reuse modal for delete

### DIFF
--- a/web/components/ConfirmModal.tsx
+++ b/web/components/ConfirmModal.tsx
@@ -1,0 +1,34 @@
+import { Modal } from "@/components/Modal";
+import { Button } from "@/components/Button";
+import type { VariantProps } from "class-variance-authority";
+import type { buttonVariants } from "@/components/Button";
+
+export const ConfirmModal = ({
+  title = "Are you sure?",
+  message,
+  confirmLabel,
+  confirmVariant = "default",
+  disabled = false,
+  onConfirm,
+  onClose,
+}: {
+  title?: string;
+  message: string;
+  confirmLabel: string;
+  confirmVariant?: VariantProps<typeof buttonVariants>["variant"];
+  disabled?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) => (
+  <Modal title={<h1 class="text-2xl font-bold">{title}</h1>} onClose={disabled ? () => {} : onClose} className="gap-y-6">
+    <p class="text-warning">{message}</p>
+    <fieldset disabled={disabled} class="flex gap-4 mt-auto">
+      <Button type="button" variant="outline" className="flex-1" onClick={onClose}>
+        Cancel
+      </Button>
+      <Button type="button" variant={confirmVariant} className="flex-1" onClick={onConfirm}>
+        {confirmLabel}
+      </Button>
+    </fieldset>
+  </Modal>
+);

--- a/web/components/EditActivityModal.tsx
+++ b/web/components/EditActivityModal.tsx
@@ -23,6 +23,7 @@ import { dateStrFromDate } from "@/data/dateStrFromDate";
 import { timeStrFromDate } from "@/data/timeStrFromDate";
 import { combineDateAndTime } from "@/data/combineDateAndTime";
 import { getDatetimeWarning } from "@/data/getDatetimeWarning";
+import { ConfirmModal } from "@/components/ConfirmModal";
 
 export const EditActivityModal = ({
   database,
@@ -35,6 +36,8 @@ export const EditActivityModal = ({
 }) => {
   const activity = useSignal<Activity | null>(null);
   const showSessionTypeModal = useSignal(false);
+  const showConfirmWarningModal = useSignal(false);
+  const showConfirmDeleteModal = useSignal(false);
   const [controlsDisabled, setControlsDisabled] = useState(false);
 
   useEffect(() => {
@@ -46,8 +49,7 @@ export const EditActivityModal = ({
     return () => database.removeEventListener("activities:changed", refreshActivity);
   }, [activityId]);
 
-  const onSubmit = async (e: SubmitEvent) => {
-    e.preventDefault();
+  const saveActivity = async () => {
     assert(activity.value);
 
     setControlsDisabled(true);
@@ -62,11 +64,65 @@ export const EditActivityModal = ({
     onClose();
   };
 
+  const onSubmit = async (e: SubmitEvent) => {
+    e.preventDefault();
+    assert(activity.value);
+
+    const submitWarning = getDatetimeWarning(activity.value.startTime, activity.value.endTime);
+    if (submitWarning) {
+      showConfirmWarningModal.value = true;
+      return;
+    }
+
+    await saveActivity();
+  };
+
   const header = <h1 class="text-2xl font-bold">Edit Activity</h1>;
 
   if (!activity.value) return <Modal title={header} onClose={onClose} className="gap-y-10" />;
 
   assert(activity.value.startTime);
+
+  const warning = getDatetimeWarning(activity.value.startTime, activity.value.endTime);
+
+  if (showConfirmDeleteModal.value) {
+    return (
+      <ConfirmModal
+        message="Delete this activity? This cannot be undone."
+        confirmLabel="Delete"
+        confirmVariant="danger"
+        disabled={controlsDisabled}
+        onClose={() => (showConfirmDeleteModal.value = false)}
+        onConfirm={async () => {
+          setControlsDisabled(true);
+          try {
+            await deleteActivity({ database }, activityId);
+          } catch (error) {
+            setControlsDisabled(false);
+            console.warn("Failed to delete activity", String(error));
+            self.alert("Failed to delete activity. Please try again.");
+            return;
+          }
+          showConfirmDeleteModal.value = false;
+          onClose();
+        }}
+      />
+    );
+  }
+
+  if (showConfirmWarningModal.value && warning) {
+    return (
+      <ConfirmModal
+        message={`${warning}. Save anyway?`}
+        confirmLabel="Save anyway"
+        onClose={() => (showConfirmWarningModal.value = false)}
+        onConfirm={async () => {
+          showConfirmWarningModal.value = false;
+          await saveActivity();
+        }}
+      />
+    );
+  }
 
   if (showSessionTypeModal.value) {
     return (
@@ -87,8 +143,6 @@ export const EditActivityModal = ({
       />
     );
   }
-
-  const warning = getDatetimeWarning(activity.value.startTime, activity.value.endTime);
 
   return (
     <Modal title={header} onClose={onClose} className="gap-y-10">
@@ -256,23 +310,7 @@ export const EditActivityModal = ({
             Save
           </Button>
 
-          <Button
-            type="button"
-            variant="danger"
-            onClick={async () => {
-              if (!self.confirm("Delete this activity? This cannot be undone.")) return;
-              setControlsDisabled(true);
-              try {
-                await deleteActivity({ database }, activityId);
-              } catch (error) {
-                setControlsDisabled(false);
-                console.warn("Failed to delete activity", String(error));
-                self.alert("Failed to delete activity. Please try again.");
-                return;
-              }
-              onClose();
-            }}
-          >
+          <Button type="button" variant="danger" onClick={() => (showConfirmDeleteModal.value = true)}>
             Delete
           </Button>
         </fieldset>

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -24,6 +24,7 @@ import { getDatetimeWarning } from "@/data/getDatetimeWarning";
 import { useEffect } from "preact/hooks";
 import { roundDateToHour } from "@/data/roundDateToHour";
 import { upsertActivity } from "@/data/upsertActivity";
+import { ConfirmModal } from "@/components/ConfirmModal";
 
 export const Home = ({ database }: { database: IDBDatabase }) => {
   const activity = useActivity();
@@ -34,6 +35,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
   const showHistoryModal = useSignal(false);
   const showCamperModal = useSignal(false);
   const showSessionTypeModal = useSignal(false);
+  const showConfirmWarningModal = useSignal(false);
 
   useEffect(() => {
     const now = roundDateToHour(new Date());
@@ -45,10 +47,9 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
     };
   }, []);
 
-  const onSubmit = async (e: SubmitEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const warning = getDatetimeWarning(activity.value.startTime, activity.value.endTime);
 
+  const saveActivity = async () => {
     controlsDisabled.value = true;
     await upsertActivity({ database }, activity.value);
     const now = roundDateToHour(new Date());
@@ -61,7 +62,17 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
     controlsDisabled.value = false;
   };
 
-  const warning = getDatetimeWarning(activity.value.startTime, activity.value.endTime);
+  const onSubmit = async (e: SubmitEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (warning) {
+      showConfirmWarningModal.value = true;
+      return;
+    }
+
+    await saveActivity();
+  };
 
   if (showSettingsModal.value) {
     return (
@@ -93,6 +104,22 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                 return { name: camper, id: existingCamper?.id ?? null };
               }),
             };
+          }}
+        />
+      </div>
+    );
+  }
+
+  if (showConfirmWarningModal.value && warning) {
+    return (
+      <div class="h-full max-w-md mx-auto p-4 space-y-6 flex flex-col gap-4 z-0">
+        <ConfirmModal
+          message={`${warning}. Save anyway?`}
+          confirmLabel="Save anyway"
+          onClose={() => (showConfirmWarningModal.value = false)}
+          onConfirm={async () => {
+            showConfirmWarningModal.value = false;
+            await saveActivity();
           }}
         />
       </div>


### PR DESCRIPTION
## Summary
- Adds a `ConfirmModal` that pops when the user clicks Save with a datetime warning (duration <1m, >2h, etc.) and asks them to confirm.
- Reuses the same modal for the Delete Activity confirmation, replacing the native `self.confirm()`.
- Keeps the delete confirm open with disabled controls while the request is in flight so the edit form doesn't flash behind it.

Test plan: tested locally — save with a sub-minute activity prompts confirm; cancel returns to form; confirm saves. Delete shows the modal, disables buttons while the request is pending, then closes.