### PR TITLE
Add unenforced 140 character counter to activity description

### DIFF
--- a/web/components/CharCounter.tsx
+++ b/web/components/CharCounter.tsx
@@ -1,0 +1,7 @@
+import { cn } from "@/cn";
+
+export const CharCounter = ({ value, max }: { value: string; max: number }) => (
+  <div class={cn("text-xs text-right mt-1", value.length > max ? "text-warning" : "text-muted-foreground")}>
+    {value.length} / {max} chars
+  </div>
+);

--- a/web/components/EditActivityModal.tsx
+++ b/web/components/EditActivityModal.tsx
@@ -11,6 +11,7 @@ import { Input } from "@/components/Input";
 import { Button } from "@/components/Button";
 import { SessionTypeModal } from "@/components/SessionTypeModal";
 import { TextArea } from "@/components/TextArea";
+import { CharCounter } from "@/components/CharCounter";
 import type { Activity } from "@/data/serialization";
 import { assert } from "@/assert";
 import type { SessionType } from "@/data/sessionTypes";
@@ -220,6 +221,7 @@ export const EditActivityModal = ({
               }}
               placeholder="Describe the current activity"
             />
+            <CharCounter value={activity.value.description} max={140} />
           </Label>
 
           <div class="flex gap-4">

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -9,6 +9,7 @@ import { SessionTypeModal } from "@/components/SessionTypeModal";
 import { SettingsButton } from "@/components/SettingsButton";
 import { SettingsModal } from "@/components/SettingsModal";
 import { TextArea } from "@/components/TextArea";
+import { CharCounter } from "@/components/CharCounter";
 import type { SessionType } from "@/data/sessionTypes";
 import { shouldClearGroup } from "@/data/shouldClearGroup";
 import { shouldClearWithWho } from "@/data/shouldClearWithWho";
@@ -204,6 +205,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                 }}
                 placeholder="Describe the current activity"
               />
+              <CharCounter value={activity.value.description} max={140} />
             </Label>
 
             <div class="flex gap-4">

--- a/web/routes/Timer.tsx
+++ b/web/routes/Timer.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { Label, LabelLike } from "@/components/Label";
 import { TextArea } from "@/components/TextArea";
+import { CharCounter } from "@/components/CharCounter";
 import { HistoryButton } from "@/components/HistoryButton";
 import { HistoryModal } from "@/components/HistoryModal";
 import { CamperModal } from "@/components/CampersModal";
@@ -195,6 +196,7 @@ export const Timer = ({ database }: { database: IDBDatabase }) => {
                 }}
                 placeholder="Describe the current activity"
               />
+              <CharCounter value={activity.value.description} max={140} />
             </Label>
 
             <div class="text-center">


### PR DESCRIPTION
## Summary
- Adds a `CharCounter` component that displays `N / 140 chars` under the activity description textarea
- Switches to the warning color when the description exceeds 140 chars; does not block saving
- Wired into both creation (Home, Timer) and the Edit Activity modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)