### PR TITLE
Return plain object from getRequestHeaders

### DIFF
--- a/src/google.ts
+++ b/src/google.ts
@@ -17,12 +17,12 @@ export class GoogleAuth {
     this.scope = scope;
   }
 
-  public async getRequestHeaders(): Promise<Headers> {
+  public async getRequestHeaders(): Promise<Record<string, string>> {
     const accessToken = await this.getAccessToken();
 
-    return new Headers({
+    return {
       Authorization: `Bearer ${accessToken}`,
-    });
+    };
   }
 
   private async getAccessToken(): Promise<string> {


### PR DESCRIPTION
## Summary
- Yesterday's switch to `new Headers(...)` in `GoogleAuth.getRequestHeaders` looked right by type, but `google-spreadsheet` hands the value to axios, which iterates headers as a plain object. A `Headers` instance has no enumerable own properties, so the `Authorization` header was silently dropped and every request came back as an unauthenticated 403 from Google.
- Returns a `Record<string, string>` instead — accurate type, and the auth header actually reaches the wire.

## Test plan
- Verified that `pnpm start` + a real Sheets call no longer 403s
- `pnpm typecheck` passes