### PR TITLE
Limit @types/node Dependabot updates to versions supported by current Node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     cooldown:
       default-days: 14
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "@types/node"
+        versions: [">=25"]
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
Adds a Dependabot ignore rule so it won't propose `@types/node` updates to versions (>=25) not supported by our current Node version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)