### PR TITLE
Delay duration warning until a date/time field is touched

### DIFF
--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -6,6 +6,47 @@ test("that the page loads", async ({ page }) => {
   await expect(page).toHaveTitle(/Care Clock/);
 });
 
+test("hides the duration warning until a date/time field is interacted with", async ({ page }) => {
+  await page.goto("/");
+
+  // The default start/end are both the current hour, a zero-length duration —
+  // but the warning should stay hidden until the user touches a field.
+  await expect(page.getByText("Activity duration is less than 1 minute")).not.toBeVisible();
+
+  // Re-entering the start time as the end time keeps the zero-length duration,
+  // now surfacing the warning because a field was interacted with.
+  const startTime = await page.getByLabel("Start Time").inputValue();
+  await page.getByLabel("End Time").fill(startTime);
+
+  await expect(page.getByText("Activity duration is less than 1 minute")).toBeVisible();
+});
+
+test("hides the duration warning again after saving", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Settings").click();
+  await page.getByLabel("Therapist").selectOption("Tori");
+  await page.getByLabel("Back").click();
+
+  await page.getByLabel("Select Campers").click();
+  await page.getByRole("button", { name: "Edit Campers" }).click();
+  await page.getByLabel("Camper Name").fill("Alice");
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByRole("button", { name: "Back" }).click(); // back to campers modal
+  await page.getByText("Alice").click();
+  await page.getByRole("button", { name: "Back" }).click(); // back to home
+
+  const startTime = await page.getByLabel("Start Time").inputValue();
+  await page.getByLabel("End Time").fill(startTime);
+  await expect(page.getByText("Activity duration is less than 1 minute")).toBeVisible();
+
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await page.getByRole("button", { name: "Save anyway" }).click();
+
+  // The form resets after saving, so the warning is hidden until the next interaction.
+  await expect(page.getByText("Activity duration is less than 1 minute")).not.toBeVisible();
+});
+
 test("Filling out the form for a group session", async ({ page }) => {
   await page.goto("/");
 

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -37,6 +37,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
   const showCamperModal = useSignal(false);
   const showSessionTypeModal = useSignal(false);
   const showConfirmWarningModal = useSignal(false);
+  const datetimeInteracted = useSignal(false);
 
   useEffect(() => {
     const now = roundDateToHour(new Date());
@@ -48,7 +49,9 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
     };
   }, []);
 
-  const warning = getDatetimeWarning(activity.value.startTime, activity.value.endTime);
+  const warning = datetimeInteracted.value
+    ? getDatetimeWarning(activity.value.startTime, activity.value.endTime)
+    : undefined;
 
   const saveActivity = async () => {
     controlsDisabled.value = true;
@@ -60,6 +63,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
       startTime: now,
       endTime: now,
     };
+    datetimeInteracted.value = false;
     controlsDisabled.value = false;
   };
 
@@ -218,6 +222,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                   onInput={(e: InputEvent) => {
                     assert(e.target instanceof HTMLInputElement);
                     assert(activity.value?.startTime);
+                    datetimeInteracted.value = true;
                     const time = timeStrFromDate(activity.value.startTime);
                     const startTime = combineDateAndTime(e.target.value, time);
 
@@ -240,6 +245,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                   onInput={(e: InputEvent) => {
                     assert(e.target instanceof HTMLInputElement);
                     assert(activity.value?.startTime);
+                    datetimeInteracted.value = true;
                     const date = dateStrFromDate(activity.value.startTime);
                     const startTime = combineDateAndTime(date, e.target.value);
 
@@ -263,6 +269,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                   onInput={(e: InputEvent) => {
                     assert(e.target instanceof HTMLInputElement);
                     assert(activity.value);
+                    datetimeInteracted.value = true;
                     const time = timeStrFromDate(activity.value.endTime);
                     const endTime = combineDateAndTime(e.target.value, time);
 
@@ -283,6 +290,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                   onInput={(e: InputEvent) => {
                     assert(e.target instanceof HTMLInputElement);
                     assert(activity.value);
+                    datetimeInteracted.value = true;
                     const date = dateStrFromDate(activity.value.endTime);
                     const endTime = combineDateAndTime(date, e.target.value);
 


### PR DESCRIPTION
## What

The **"Activity duration is less than 1 minute"** warning was shown on the fresh Home form before the user had interacted with anything — the start/end times both default to the current hour, a zero-length duration that immediately trips the warning.

## Change

- Track whether the user has interacted with any of the 4 date/time fields (start/end date/time) on the Home form.
- Only surface the datetime warning once a field has been touched.
- Reset the interaction flag when an activity is saved, so the warning stays hidden on the freshly-reset form until the user touches a field again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)