### PR TITLE
Show a toast after saving an activity

### DIFF
--- a/e2e/save-activity-toast.spec.ts
+++ b/e2e/save-activity-toast.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const fillActivity = async (page: Page, { description }: { description: string }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Settings").click();
+  await page.getByLabel("Therapist").selectOption("Tori");
+  await page.getByLabel("Back").click();
+
+  await page.getByLabel("Select Campers").click();
+  await page.getByRole("button", { name: "Edit Campers" }).click();
+  await page.getByLabel("Camper Name").fill("Alice");
+  await page.getByRole("button", { name: "Add" }).click();
+  await page.getByRole("button", { name: "Back" }).click();
+  await page.getByText("Alice").click();
+  await page.getByRole("button", { name: "Back" }).click();
+
+  await page.getByLabel("Select Session Type").click();
+  await page.getByRole("button", { name: "Select Individual" }).click();
+
+  await page.getByLabel("Description").fill(description);
+
+  // Push the end out by an hour so the save proceeds without the
+  // confirm-warning modal (see edit-activity.spec.ts for the rationale).
+  const startDate = await page.getByLabel("Start Date").inputValue();
+  const startTime = await page.getByLabel("Start Time").inputValue();
+  const end = new Date(`${startDate}T${startTime}`);
+  end.setHours(end.getHours() + 1);
+
+  const pad = (n: number) => String(n).padStart(2, "0");
+  await page.getByLabel("End Date").fill(`${end.getFullYear()}-${pad(end.getMonth() + 1)}-${pad(end.getDate())}`);
+  await page.getByLabel("End Time").fill(`${pad(end.getHours())}:${pad(end.getMinutes())}:${pad(end.getSeconds())}`);
+};
+
+test("saving an activity shows a confirmation toast", async ({ page }) => {
+  await fillActivity(page, { description: "A saved activity" });
+
+  await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.getByRole("status")).toHaveText("Activity saved");
+});

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -3,6 +3,7 @@ import { LocationProvider, ErrorBoundary, Router, Route } from "preact-iso";
 import { Home } from "./routes/Home";
 import { Timer } from "./routes/Timer";
 import { NotFound } from "./routes/404";
+import { Toaster } from "./components/Toaster";
 
 export const App = ({ database }: { database: IDBDatabase }) => (
   <LocationProvider>
@@ -12,6 +13,7 @@ export const App = ({ database }: { database: IDBDatabase }) => (
         <Route path="/timer" component={Timer} database={database} />
         <NotFound default />
       </Router>
+      <Toaster />
     </ErrorBoundary>
   </LocationProvider>
 );

--- a/web/components/EditActivityModal.tsx
+++ b/web/components/EditActivityModal.tsx
@@ -25,6 +25,7 @@ import { timeStrFromDate } from "@/data/timeStrFromDate";
 import { combineDateAndTime } from "@/data/combineDateAndTime";
 import { getDatetimeWarning } from "@/data/getDatetimeWarning";
 import { ConfirmModal } from "@/components/ConfirmModal";
+import { showToast } from "@/data/toast";
 
 export const EditActivityModal = ({
   database,
@@ -62,6 +63,7 @@ export const EditActivityModal = ({
       },
     );
     setControlsDisabled(false);
+    showToast("Activity saved");
     onClose();
   };
 

--- a/web/components/Toaster.tsx
+++ b/web/components/Toaster.tsx
@@ -1,0 +1,14 @@
+import { toastMessage } from "@/data/toast";
+
+export const Toaster = () => {
+  if (!toastMessage.value) return null;
+
+  return (
+    <div
+      role="status"
+      class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 rounded-lg bg-foreground text-background px-4 py-2 text-sm font-medium shadow-lg"
+    >
+      {toastMessage.value}
+    </div>
+  );
+};

--- a/web/data/toast.ts
+++ b/web/data/toast.ts
@@ -1,0 +1,12 @@
+import { signal } from "@preact/signals";
+
+export const toastMessage = signal<string | null>(null);
+
+let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+export const showToast = (message: string) => {
+  toastMessage.value = message;
+
+  if (timeoutId) clearTimeout(timeoutId);
+  timeoutId = setTimeout(() => (toastMessage.value = null), 3000);
+};

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -26,6 +26,7 @@ import { useEffect } from "preact/hooks";
 import { roundDateToHour } from "@/data/roundDateToHour";
 import { upsertActivity } from "@/data/upsertActivity";
 import { ConfirmModal } from "@/components/ConfirmModal";
+import { showToast } from "@/data/toast";
 
 export const Home = ({ database }: { database: IDBDatabase }) => {
   const activity = useActivity();
@@ -61,6 +62,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
       endTime: now,
     };
     controlsDisabled.value = false;
+    showToast("Activity saved");
   };
 
   const onSubmit = async (e: SubmitEvent) => {


### PR DESCRIPTION
Show a confirmation toast notification after a user successfully saves an activity.

## What
- Adds a lightweight toast system (`@preact/signals`-backed `showToast` + a `Toaster` component rendered at the app root).
- Triggers "Activity saved" after the create (Home) and edit (EditActivityModal) save flows succeed.

## Testing
- New Playwright E2E test asserts the toast appears after clicking Save. Written failing-first per TDD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)