### PR TITLE
Add camper import flow

### DIFF
--- a/e2e/camper-import.spec.ts
+++ b/e2e/camper-import.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+test("lists the campers from the query params", async ({ page }) => {
+  await page.goto("/camper-import?camper=Fred+W.&camper=Bob+F.");
+
+  await expect(page.getByText("Fred W.")).toBeVisible();
+  await expect(page.getByText("Bob F.")).toBeVisible();
+});
+
+test("confirming stores the campers and returns home", async ({ page }) => {
+  await page.goto("/camper-import?camper=Fred+W.&camper=Bob+F.");
+
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  // back on the home page
+  await expect(page.getByRole("heading", { name: "Care Clock" })).toBeVisible();
+
+  // the imported campers are now available to select
+  await page.getByLabel("Select Campers").click();
+  await expect(page.getByText("Fred W.")).toBeVisible();
+  await expect(page.getByText("Bob F.")).toBeVisible();
+});
+
+test("confirming merges with existing campers without duplicating", async ({ page }) => {
+  await page.goto("/");
+  await page.evaluate(() => localStorage.setItem("campers", JSON.stringify(["Bob F.", "Zoe Q."])));
+
+  await page.goto("/camper-import?camper=Fred+W.&camper=Bob+F.");
+  await page.getByRole("button", { name: "Confirm" }).click();
+
+  const campers = await page.evaluate(() => JSON.parse(localStorage.getItem("campers") ?? "[]"));
+  expect(campers).toEqual(["Bob F.", "Fred W.", "Zoe Q."]);
+});
+
+test("cancelling discards the campers and returns home", async ({ page }) => {
+  await page.goto("/camper-import?camper=Fred+W.&camper=Bob+F.");
+
+  await page.getByRole("button", { name: "Cancel" }).click();
+
+  await expect(page.getByRole("heading", { name: "Care Clock" })).toBeVisible();
+
+  const campers = await page.evaluate(() => JSON.parse(localStorage.getItem("campers") ?? "[]"));
+  expect(campers).toEqual([]);
+});

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -1,6 +1,7 @@
 import { LocationProvider, ErrorBoundary, Router, Route } from "preact-iso";
 
 import { Home } from "./routes/Home";
+import { CamperImport } from "./routes/CamperImport";
 import { Timer } from "./routes/Timer";
 import { NotFound } from "./routes/404";
 import { Toaster } from "./components/Toaster";
@@ -10,6 +11,7 @@ export const App = ({ database }: { database: IDBDatabase }) => (
     <ErrorBoundary>
       <Router>
         <Route path="/" component={Home} database={database} />
+        <Route path="/camper-import" component={CamperImport} database={database} />
         <Route path="/timer" component={Timer} database={database} />
         <NotFound default />
       </Router>

--- a/web/routes/CamperImport.tsx
+++ b/web/routes/CamperImport.tsx
@@ -1,0 +1,56 @@
+import { useLocation } from "preact-iso";
+
+import { Button } from "@/components/Button";
+import { Card, CardContent } from "@/components/Card";
+import { useAvailableCampers } from "@/data/useAvailableCampers";
+import { showToast } from "@/data/toast";
+
+export const CamperImport = () => {
+  const { url, route } = useLocation();
+  const availableCampers = useAvailableCampers();
+
+  const search = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+  const campers = new URLSearchParams(search).getAll("camper");
+
+  const onConfirm = () => {
+    const merged = [...new Set([...availableCampers.value, ...campers])].sort();
+    // Persist directly so the write lands before route("/") unmounts us and the
+    // signal effect would otherwise flush.
+    localStorage.setItem("campers", JSON.stringify(merged));
+    availableCampers.value = merged;
+    showToast(`Imported ${campers.length} ${campers.length === 1 ? "camper" : "campers"}`);
+    route("/");
+  };
+
+  const onCancel = () => route("/");
+
+  return (
+    <div class="h-full max-w-md mx-auto p-4 space-y-6 flex flex-col gap-4 z-0">
+      <header class="text-center">
+        <h1 class="text-2xl font-bold text-primary">Import Campers</h1>
+      </header>
+
+      <Card className="flex-1">
+        <CardContent className="p-4 space-y-4 h-full flex flex-col">
+          <p class="text-secondary">The following campers will be added to your device:</p>
+
+          <ul class="flex flex-col divide-y-1 divide-secondary/40">
+            {campers.length === 0 && <li class="text-center text-secondary py-4">No campers to import</li>}
+            {campers.map((camper) => (
+              <li class="py-2 px-4">{camper}</li>
+            ))}
+          </ul>
+
+          <div class="flex gap-4 mt-auto">
+            <Button type="button" variant="outline" class="flex-1" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button type="button" class="flex-1" onClick={onConfirm} disabled={campers.length === 0}>
+              Confirm
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/web/routes/CamperImport.tsx
+++ b/web/routes/CamperImport.tsx
@@ -41,12 +41,12 @@ export const CamperImport = () => {
             ))}
           </ul>
 
-          <div class="flex gap-4 mt-auto">
-            <Button type="button" variant="outline" class="flex-1" onClick={onCancel}>
-              Cancel
-            </Button>
-            <Button type="button" class="flex-1" onClick={onConfirm} disabled={campers.length === 0}>
+          <div class="flex flex-col gap-4 mt-auto">
+            <Button type="button" onClick={onConfirm} disabled={campers.length === 0}>
               Confirm
+            </Button>
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancel
             </Button>
           </div>
         </CardContent>


### PR DESCRIPTION
## What

Adds a camper import flow so therapists can be sent a URL that pre-loads their caseload.

- New `/camper-import` route. Campers are passed as repeated `camper` query params, e.g. `https://care-clock.com/camper-import?camper=Fred+W.&camper=Bob+F.` — parsed with `URLSearchParams.getAll("camper")`.
- Lists the campers to be imported and asks for confirmation.
- **Confirm**: merges the campers into the device's stored list (`localStorage["campers"]`, deduped + sorted) — the same storage the manual add-camper feature uses — shows a toast, and returns home.
- **Cancel**: discards the list and returns home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)