### PR TITLE
Migrate GitHub Actions to Node 24 runtime + fix flaky clear-all-campers test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,14 +9,14 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version-file: .node-version
     - run: corepack enable
     - id: pnpm-store
       run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ${{ steps.pnpm-store.outputs.path }}
         key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -38,7 +38,7 @@ jobs:
         } > .dev.vars
     - name: Run Playwright tests
       run: pnpm test
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ !cancelled() }}
       with:
         name: playwright-report

--- a/e2e/steps/camper-import.steps.ts
+++ b/e2e/steps/camper-import.steps.ts
@@ -21,6 +21,7 @@ Then("the stored campers should be {string}", async ({ page }, list: string) => 
 });
 
 Then("the stored campers should be empty", async ({ page }) => {
-  const campers = await page.evaluate(() => JSON.parse(localStorage.getItem("campers") ?? "[]"));
-  expect(campers).toEqual([]);
+  await expect
+    .poll(() => page.evaluate(() => JSON.parse(localStorage.getItem("campers") ?? "[]")))
+    .toEqual([]);
 });


### PR DESCRIPTION
## What

Two related findings from CI run #27507883994.

### 1. GitHub Actions Node 20 → 24 runtime deprecation
GitHub force-migrates JavaScript actions from the Node.js 20 runtime to Node 24 on **June 16th, 2026** (CI was emitting a deprecation warning in the final step). Bump each action to its latest major, which runs on Node 24 natively:

- `actions/checkout` v4 → v6
- `actions/setup-node` v4 → v6
- `actions/cache` v4 → v5
- `actions/upload-artifact` v4 → v7

The app's own Node version (`.node-version` → `v24.16.0`) is already the latest LTS, so no runtime pin changed.

### 2. Flaky test that let the build go green despite a failure
That run showed `1 flaky, 17 passed` — the `clear-all-campers` scenario failed once then passed on retry (`retries: 2`), so CI exited 0. Root cause: the `the stored campers should be empty` step read `localStorage` a single time, racing the async clear write, so it could observe stale campers. Fixed by polling until the value settles — mirroring the existing `should be {string}` step right above it.

Verified: previously-flaky scenario run 15× with `--retries=0` (0 failures), full suite 18/18 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)