### PR TITLE
Fix #260 CI: read fieldset disabled from signal value

### DIFF
--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -155,7 +155,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
 
   return (
     <form class="h-full max-w-md shadow-lg mx-auto p-4 space-y-6 flex flex-col gap-4 z-0" onSubmit={onSubmit}>
-      <fieldset disabled={controlsDisabled} className="flex flex-col gap-4">
+      <fieldset disabled={controlsDisabled.value} className="flex flex-col gap-4">
         <header class="text-center relative">
           <SettingsButton onClick={() => (showSettingsModal.value = true)} class="absolute top-0 left-4" />
           <h1 class="text-2xl font-bold text-primary">Care Clock</h1>

--- a/web/routes/Timer.tsx
+++ b/web/routes/Timer.tsx
@@ -140,7 +140,7 @@ export const Timer = ({ database }: { database: IDBDatabase }) => {
 
   return (
     <form class="h-full max-w-md shadow-lg mx-auto p-4 space-y-6 flex flex-col gap-4 z-0" onSubmit={onSubmit}>
-      <fieldset disabled={controlsDisabled} className="flex flex-col gap-4">
+      <fieldset disabled={controlsDisabled.value} className="flex flex-col gap-4">
         <header class="text-center relative">
           <SettingsButton onClick={() => (showSettingsModal.value = true)} class="absolute top-0 left-4" />
           <h1 class="text-2xl font-bold text-primary">Care Clock</h1>


### PR DESCRIPTION
Targets the Dependabot branch for #260 so it merges **into** that PR and adds only the fix on top of the dependency bumps (no duplicated package changes).

## Problem

#260's CI fails on the Playwright `edit-activity` tests — the History button times out with `element is not enabled`.

## Root cause

The History button lives inside `<fieldset disabled={controlsDisabled}>` in `Home.tsx` and `Timer.tsx`, where `controlsDisabled` is a `useSignal(false)`. The code bound the **raw Signal** to the `disabled` attribute and relied on `@preact/signals` to unwrap it.

`@preact/signals` 2.9.1 ([PR #924](https://github.com/preactjs/signals/pull/924)) stopped writing peeked signal values back into `vnode.props` after diffing. Now, on any parent rerender, Preact re-applies the prop as the raw Signal object — always truthy — so the fieldset (and the History button inside it) stays permanently disabled.

## Fix

Read `controlsDisabled.value` explicitly in the two fieldsets, matching how the rest of these components already read signals. Diff is just those two lines; all 18 e2e tests pass.