### PR TITLE
Fix iOS app icon showing 'C' instead of logo

### DIFF
--- a/e2e/features/app-icon.feature
+++ b/e2e/features/app-icon.feature
@@ -1,0 +1,6 @@
+Feature: App icon
+
+  Scenario: iOS has a non-maskable apple-touch-icon
+    When I open the home page
+    Then the page should declare an apple-touch-icon
+    And the apple-touch-icon should load successfully

--- a/e2e/steps/app-icon.steps.ts
+++ b/e2e/steps/app-icon.steps.ts
@@ -1,0 +1,14 @@
+import { expect } from "@playwright/test";
+import { Then } from "./fixtures";
+
+Then("the page should declare an apple-touch-icon", async ({ page }) => {
+  await expect(page.locator('link[rel="apple-touch-icon"]')).toHaveCount(1);
+});
+
+Then("the apple-touch-icon should load successfully", async ({ page }) => {
+  const href = await page.locator('link[rel="apple-touch-icon"]').getAttribute("href");
+  expect(href, "apple-touch-icon must have an href").toBeTruthy();
+
+  const response = await page.request.get(new URL(href ?? "", page.url()).toString());
+  expect(response.ok()).toBe(true);
+});

--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
       name="description"
       content="Track therapy time spent with campers"
     />
-    <link rel="icon" href="./favicon.png"> 
+    <link rel="icon" href="./favicon.png">
+    <link rel="apple-touch-icon" href="./favicon.png" />
     <link rel="manifest" href="./manifest.json" />
     <title>Care Clock</title>
   </head>


### PR DESCRIPTION
## Problem

The iOS home-screen icon showed a generated "C" instead of the Care Clock logo.

iOS does not use SVG manifest icons for the home screen — it relies on an `apple-touch-icon` link tag with a raster image. The manifest only declared SVG icons (one `purpose: "any"`, one `purpose: "maskable"`), and `index.html` had no `apple-touch-icon`, so iOS had no usable icon and fell back to generating one from the app name.

## Fix

Add an `apple-touch-icon` link in `index.html` pointing at the existing non-maskable `favicon.png` (the logo). Android continues using the `purpose: "maskable"` manifest entry, so both coexist.

Added a Cucumber scenario asserting the page declares an `apple-touch-icon` and that it loads successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)