### PR TITLE
Upgrade hono to address CVE-2026-54290

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "date-fns": "^4.4.0",
     "google-auth-library": "^10.6.2",
     "google-spreadsheet": "^5.2.0",
-    "hono": "^4.12.23",
+    "hono": "^4.12.25",
     "preact-iso": "^2.12.0",
     "preact-jsx-runtime": "^1.2.0",
     "uuid": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0(google-auth-library@10.6.2)
       hono:
-        specifier: ^4.12.23
-        version: 4.12.23
+        specifier: ^4.12.25
+        version: 4.12.25
       preact-iso:
         specifier: ^2.12.0
         version: 2.12.0(preact-render-to-string@6.5.13(preact@10.29.2))(preact@10.29.2)
@@ -1383,8 +1383,8 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@9.0.3:
@@ -3163,7 +3163,7 @@ snapshots:
 
   he@1.2.0: {}
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   hosted-git-info@9.0.3:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,6 @@ allowBuilds:
   sharp: true
   workerd: true
 minimumReleaseAge: 20160
+minimumReleaseAgeExclude:
+  # Remove on or after 2026-06-23, once 4.12.25 clears the 14-day minimumReleaseAge.
+  - hono@4.12.25


### PR DESCRIPTION
Resolves Dependabot alert #94 (GHSA-88fw-hqm2-52qc / CVE-2026-54290, **high**).

## Vulnerability
hono's CORS middleware reflected any request `Origin` and sent `Access-Control-Allow-Credentials: true` when `credentials: true` was set and `origin` was left at the default wildcard — exposing cookie-authenticated endpoints to arbitrary origins.

- **Vulnerable range:** `< 4.12.25`
- **First patched:** `4.12.25`
- **This change:** `hono` 4.12.23 → 4.12.25

Verified with `pnpm why -r hono`: the single resolved version is `4.12.25` (≥ patch). No source changes — lockfile, the `package.json` range bump pnpm applied, and a scoped age exemption.

## minimumReleaseAge exemption
`4.12.25` is 8 days old, below the repo's `minimumReleaseAge: 20160` (14-day) floor, so pnpm refuses it by default. With the user's approval, the **exact version** is exempted via `minimumReleaseAgeExclude` (not a bare package name — that would wave through every future release too):

```yaml
minimumReleaseAgeExclude:
  # Remove on or after 2026-06-23, once 4.12.25 clears the 14-day minimumReleaseAge.
  - hono@4.12.25
```

The global floor is untouched for every other package. The entry can be removed on/after **2026-06-23** (publish date + 14 days). Versioned exclude selectors work on the installed pnpm 11.1.2 — no pnpm upgrade required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)