### PR TITLE
Upgrade uuid to address CVE-2026-41907

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  uuid@<11.1.1: 11.1.1
+
 importers:
 
   .:
@@ -16,10 +19,10 @@ importers:
         version: 4.4.0
       google-auth-library:
         specifier: ^10.6.2
-        version: 10.6.2
+        version: 10.6.2(supports-color@10.2.2)
       google-spreadsheet:
         specifier: ^5.2.0
-        version: 5.2.0(google-auth-library@10.6.2)
+        version: 5.2.0(google-auth-library@10.6.2(supports-color@10.2.2))
       hono:
         specifier: ^4.12.25
         version: 4.12.25
@@ -50,7 +53,7 @@ importers:
         version: 1.60.0
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(supports-color@10.2.2)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))
       '@preact/signals':
         specifier: ^2.9.1
         version: 2.9.1(preact@10.29.2)
@@ -1896,13 +1899,8 @@ packages:
   util-arity@1.1.0:
     resolution: {integrity: sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==}
 
-  uuid@10.0.0:
-    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@11.0.5:
-    resolution: {integrity: sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   uuid@14.0.0:
@@ -2226,7 +2224,7 @@ snapshots:
       '@cucumber/ci-environment': 13.0.0
       '@cucumber/cucumber-expressions': 19.0.1
       '@cucumber/gherkin': 39.1.0
-      '@cucumber/gherkin-streams': 6.0.0(@cucumber/gherkin@39.1.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@27.2.0))(@cucumber/messages@32.3.1)
+      '@cucumber/gherkin-streams': 6.0.0(@cucumber/gherkin@39.1.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@32.3.1))(@cucumber/messages@32.3.1)
       '@cucumber/gherkin-utils': 11.0.0
       '@cucumber/html-formatter': 23.1.0(@cucumber/messages@32.3.1)
       '@cucumber/junit-xml-formatter': 0.13.3(@cucumber/messages@32.3.1)
@@ -2258,7 +2256,7 @@ snapshots:
       yaml: 2.9.0
       yup: 1.7.1
 
-  '@cucumber/gherkin-streams@6.0.0(@cucumber/gherkin@39.1.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@27.2.0))(@cucumber/messages@32.3.1)':
+  '@cucumber/gherkin-streams@6.0.0(@cucumber/gherkin@39.1.0)(@cucumber/message-streams@4.1.1(@cucumber/messages@32.3.1))(@cucumber/messages@32.3.1)':
     dependencies:
       '@cucumber/gherkin': 39.1.0
       '@cucumber/message-streams': 4.1.1(@cucumber/messages@32.3.1)
@@ -2332,14 +2330,14 @@ snapshots:
       '@types/uuid': 10.0.0
       class-transformer: 0.5.1
       reflect-metadata: 0.2.2
-      uuid: 10.0.0
+      uuid: 11.1.1
 
   '@cucumber/messages@27.2.0':
     dependencies:
       '@types/uuid': 10.0.0
       class-transformer: 0.5.1
       reflect-metadata: 0.2.2
-      uuid: 11.0.5
+      uuid: 11.1.1
 
   '@cucumber/messages@32.3.1':
     dependencies:
@@ -2619,7 +2617,7 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.2)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.2)(supports-color@10.2.2)(vite@8.0.16(@types/node@24.12.4)(esbuild@0.27.3)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
@@ -3109,17 +3107,17 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  gaxios@7.1.4:
+  gaxios@7.1.4(supports-color@10.2.2):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.2.2)
       node-fetch: 3.3.2
     transitivePeerDependencies:
       - supports-color
 
   gcp-metadata@8.1.2:
     dependencies:
-      gaxios: 7.1.4
+      gaxios: 7.1.4(supports-color@10.2.2)
       google-logging-utils: 1.1.3
       json-bigint: 1.0.0
     transitivePeerDependencies:
@@ -3135,11 +3133,11 @@ snapshots:
     dependencies:
       ini: 4.1.1
 
-  google-auth-library@10.6.2:
+  google-auth-library@10.6.2(supports-color@10.2.2):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.4
+      gaxios: 7.1.4(supports-color@10.2.2)
       gcp-metadata: 8.1.2
       google-logging-utils: 1.1.3
       jws: 4.0.1
@@ -3148,12 +3146,12 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
-  google-spreadsheet@5.2.0(google-auth-library@10.6.2):
+  google-spreadsheet@5.2.0(google-auth-library@10.6.2(supports-color@10.2.2)):
     dependencies:
       es-toolkit: 1.46.1
       ky: 1.14.3
     optionalDependencies:
-      google-auth-library: 10.6.2
+      google-auth-library: 10.6.2(supports-color@10.2.2)
 
   graceful-fs@4.2.11: {}
 
@@ -3169,7 +3167,7 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@10.2.2):
     dependencies:
       agent-base: 7.1.3
       debug: 4.4.3(supports-color@10.2.2)
@@ -3629,9 +3627,7 @@ snapshots:
 
   util-arity@1.1.0: {}
 
-  uuid@10.0.0: {}
-
-  uuid@11.0.5: {}
+  uuid@11.1.1: {}
 
   uuid@14.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,11 @@ allowBuilds:
   sharp: true
   workerd: true
 minimumReleaseAge: 20160
+overrides:
+  # CVE-2026-41907 (GHSA-w5hq-g745-h8pq): uuid < 11.1.1 misses buffer bounds
+  # checks in v3/v5/v6. Pulled in transitively by @cucumber/messages under
+  # playwright-bdd, which caps it below the patched release.
+  'uuid@<11.1.1': 11.1.1
 minimumReleaseAgeExclude:
   # Remove on or after 2026-06-23, once 4.12.25 clears the 14-day minimumReleaseAge.
   - hono@4.12.25


### PR DESCRIPTION
Fixes [Dependabot alert #83](https://github.com/royvandewater/care-clock/security/dependabot/83).

## Vulnerability
- **CVE-2026-41907** / GHSA-w5hq-g745-h8pq — medium severity (CWE-787 out-of-bounds write)
- `uuid` `< 11.1.1` misses buffer bounds checks in the `v3()`/`v5()`/`v6()` APIs, allowing silent partial writes into caller-provided buffers. First patched in 11.1.1.

## What was vulnerable
The vulnerable versions `uuid@10.0.0` and `uuid@11.0.5` were pulled in **transitively** by `@cucumber/messages` (26.0.1 and 27.2.0) under `playwright-bdd@8.5.1` (a devDependency). `@cucumber/messages` pins uuid to an *exact* version, and `playwright-bdd@8.5.1` caps `@cucumber/messages` at `^27.2.0`, so a direct `pnpm update uuid` (and `pnpm update` on the cucumber parents) couldn't move it. Upgrading `playwright-bdd` to a uuid-free major (9.x) would not be a lockfile-only change and risks the BDD test suite.

## Fix
Added a scoped pnpm override pinning the vulnerable range to the first patched version:

```yaml
overrides:
  'uuid@<11.1.1': 11.1.1
```

After install, all resolved versions are `uuid@11.1.1` and `uuid@14.0.0` — both patched.

**This is a lockfile + workspace-config-only diff** (`pnpm-lock.yaml` + `pnpm-workspace.yaml`); no application code or `package.json` dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)