### PR TITLE
Upgrade js-yaml to address CVE-2026-53550

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1449,8 +1449,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2935,7 +2935,7 @@ snapshots:
   chanfana@3.3.0:
     dependencies:
       '@asteasolutions/zod-to-openapi': 8.5.0(zod@4.4.3)
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       openapi3-ts: 4.5.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -3205,7 +3205,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Bumps `js-yaml` from 4.1.1 to 4.2.0 to resolve [Dependabot alert #91](https://github.com/royvandewater/care-clock/security/dependabot/91).

- **CVE:** CVE-2026-53550 (GHSA-h67p-54hq-rp68)
- **Severity:** Medium
- **Issue:** Quadratic-complexity DoS in merge key handling via repeated aliases
- **Vulnerable range:** `<= 4.1.1`
- **First patched:** 4.2.0

`js-yaml` is a transitive dependency (via `chanfana`). A direct `pnpm update js-yaml` lifted the single resolved version to 4.2.0; `pnpm why -r js-yaml` confirms no remaining vulnerable versions.

**This is a lockfile-only diff** — no `package.json` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)