### PR TITLE
Update therapist list

### DIFF
--- a/e2e/features/edit-activity.feature
+++ b/e2e/features/edit-activity.feature
@@ -2,7 +2,7 @@ Feature: Edit activity
 
   Scenario: editing an activity persists the new description
     Given I open the home page
-    And the therapist is set to "Tori"
+    And the therapist is set to "Miss Amanda"
     And the camper "Alice" has been added and selected
     And I select the "Individual" session type
     And I fill in the description with "Initial description"
@@ -19,7 +19,7 @@ Feature: Edit activity
   Scenario: deleting an activity removes it from history
     Given the activity delete request will succeed
     And I open the home page
-    And the therapist is set to "Tori"
+    And the therapist is set to "Miss Amanda"
     And the camper "Alice" has been added and selected
     And I select the "Individual" session type
     And I fill in the description with "To be deleted"

--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -12,7 +12,7 @@ Feature: Home page
 
   Scenario: hides the duration warning again after saving
     Given I open the home page
-    And the therapist is set to "Tori"
+    And the therapist is set to "Miss Amanda"
     And the camper "Alice" has been added and selected
     When I enter the start time as the end time
     Then I should see "Activity duration is less than 1 minute"
@@ -21,7 +21,7 @@ Feature: Home page
 
   Scenario: Filling out the form for a group session
     Given I open the home page
-    And the therapist is set to "Tori"
+    And the therapist is set to "Miss Amanda"
     And the camper "Alice" has been added and selected
     When I select the "Group" session type
     And I fill in the group with "Automated Tests"
@@ -29,15 +29,15 @@ Feature: Home page
 
   Scenario: Filling out the form for a co-treat session
     Given I open the home page
-    And the therapist is set to "Tori"
+    And the therapist is set to "Miss Amanda"
     And the camper "Alice" has been added and selected
     When I select the "Co-Treat" session type
-    And I fill in "With Who" with "Valerie"
+    And I fill in "With Who" with "Miss Valerie"
     And I fill in the description with "Running automated tests"
 
   Scenario: Filling out the form for an individual session
     Given I open the home page
-    And the therapist is set to "Tori"
+    And the therapist is set to "Miss Amanda"
     And the camper "Alice" has been added and selected
     When I select the "Individual" session type
     And I fill in the description with "Running automated tests"

--- a/e2e/features/save-activity-toast.feature
+++ b/e2e/features/save-activity-toast.feature
@@ -2,7 +2,7 @@ Feature: Save activity toast
 
   Scenario: saving an activity shows a confirmation toast
     Given I open the home page
-    And the therapist is set to "Tori"
+    And the therapist is set to "Miss Amanda"
     And the camper "Alice" has been added and selected
     And I select the "Individual" session type
     And I fill in the description with "A saved activity"

--- a/web/data/therapists.ts
+++ b/web/data/therapists.ts
@@ -1,2 +1,15 @@
-export const therapists = ["Tori", "Valerie", "Stephanie"] as const;
+export const therapists = [
+  "Miss Amanda",
+  "Miss Ashlea",
+  "Miss Carolyn",
+  "Miss Danielle",
+  "Miss Kaitie",
+  "Miss Katie",
+  "Miss Kourtney",
+  "Miss Valerie",
+  "Mr. Marty",
+  "Mr. Rob",
+  "Mrs. Stephanie",
+  "Ms. Denise",
+] as const;
 export type Therapist = (typeof therapists)[number];


### PR DESCRIPTION
Replaces the hardcoded therapist list in `web/data/therapists.ts` with the current set of names.

Old: Tori, Valerie, Stephanie

New (12):
- Miss Amanda
- Miss Ashlea
- Miss Carolyn
- Miss Danielle
- Miss Kaitie
- Miss Katie
- Miss Kourtney
- Miss Valerie
- Mr. Marty
- Mr. Rob
- Mrs. Stephanie
- Ms. Denise

Note: "Miss Kaitie" and "Miss Katie" differ by one letter — both included as provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)