### PR TITLE
Sort therapists by name, not honorific

### DIFF
--- a/e2e/features/therapist-order.feature
+++ b/e2e/features/therapist-order.feature
@@ -1,0 +1,18 @@
+Feature: Therapist ordering
+
+  Scenario: therapists are listed by name, ignoring their honorific
+    Given I open the home page
+    When I open the settings
+    Then the therapist options should be in the order:
+      | Miss Amanda    |
+      | Miss Ashlea    |
+      | Miss Carolyn   |
+      | Miss Danielle  |
+      | Ms. Denise     |
+      | Miss Kaitie    |
+      | Miss Katie     |
+      | Miss Kourtney  |
+      | Mr. Marty      |
+      | Mr. Rob        |
+      | Mrs. Stephanie |
+      | Miss Valerie   |

--- a/e2e/steps/therapist-order.steps.ts
+++ b/e2e/steps/therapist-order.steps.ts
@@ -1,0 +1,15 @@
+import { expect } from "@playwright/test";
+import { When, Then } from "./fixtures";
+
+When("I open the settings", async ({ page }) => {
+  await page.getByLabel("Settings").click();
+});
+
+Then(
+  "the therapist options should be in the order:",
+  async ({ page }, table: { raw: () => string[][] }) => {
+    const expected = table.raw().map(([name]) => name);
+    const options = page.getByLabel("Therapist").locator("option");
+    await expect(options).toHaveText(["Select a therapist", ...expected]);
+  },
+);

--- a/web/data/therapists.ts
+++ b/web/data/therapists.ts
@@ -1,21 +1,15 @@
-const unsortedTherapists = [
+export const therapists = [
   "Miss Amanda",
   "Miss Ashlea",
   "Miss Carolyn",
   "Miss Danielle",
+  "Ms. Denise",
   "Miss Kaitie",
   "Miss Katie",
   "Miss Kourtney",
-  "Miss Valerie",
   "Mr. Marty",
   "Mr. Rob",
   "Mrs. Stephanie",
-  "Ms. Denise",
+  "Miss Valerie",
 ] as const;
-export type Therapist = (typeof unsortedTherapists)[number];
-
-const nameWithoutHonorific = (therapist: Therapist): string => therapist.replace(/^\S+\s+/, "");
-
-export const therapists: readonly Therapist[] = [...unsortedTherapists].sort((a, b) =>
-  nameWithoutHonorific(a).localeCompare(nameWithoutHonorific(b)),
-);
+export type Therapist = (typeof therapists)[number];

--- a/web/data/therapists.ts
+++ b/web/data/therapists.ts
@@ -1,4 +1,4 @@
-export const therapists = [
+const unsortedTherapists = [
   "Miss Amanda",
   "Miss Ashlea",
   "Miss Carolyn",
@@ -12,4 +12,10 @@ export const therapists = [
   "Mrs. Stephanie",
   "Ms. Denise",
 ] as const;
-export type Therapist = (typeof therapists)[number];
+export type Therapist = (typeof unsortedTherapists)[number];
+
+const nameWithoutHonorific = (therapist: Therapist): string => therapist.replace(/^\S+\s+/, "");
+
+export const therapists: readonly Therapist[] = [...unsortedTherapists].sort((a, b) =>
+  nameWithoutHonorific(a).localeCompare(nameWithoutHonorific(b)),
+);


### PR DESCRIPTION
## What

Therapists were displayed grouped by their honorific (all "Miss" first, then "Mr.", "Mrs.", "Ms."). They now sort by the name following the honorific, so the dropdowns read alphabetically by actual name.

## How

`web/data/therapists.ts` keeps the raw list as the source of the `Therapist` union type, then exports it sorted by the name with the leading honorific token stripped (`/^\S+\s+/`). All three consumers (`GroupOrWithWho`, `EditActivityModal`, `SettingsModal`) map over the exported array, so they all pick up the new order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)