### PR TITLE
Upgrade undici to address CVE-2026-9697

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   uuid@<11.1.1: 11.1.1
   esbuild@>=0.27.3 <0.28.1: 0.28.1
+  undici@>=7.23.0 <7.28.0: 7.28.0
 
 importers:
 
@@ -1914,8 +1915,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.24.8:
-    resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -3405,7 +3406,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.24.8
+      undici: 7.28.0
       workerd: 1.20260601.1
       ws: 8.20.1
       youch: 4.1.0-beta.10
@@ -3692,7 +3693,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.24.8: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,9 +15,15 @@ overrides:
   # via the dev server on Windows. vite and wrangler pin esbuild to 0.27.3
   # exactly, so force the patched release.
   'esbuild@>=0.27.3 <0.28.1': 0.28.1
+  # CVE-2026-9697 (GHSA-vmh5-mc38-953g): undici >= 7.23.0 < 7.28.0 bypasses TLS
+  # certificate validation via dropped requestTls in the SOCKS5 ProxyAgent.
+  # Pulled in transitively by miniflare under wrangler/@cloudflare/vite-plugin.
+  'undici@>=7.23.0 <7.28.0': 7.28.0
 minimumReleaseAgeExclude:
   # Remove on or after 2026-06-23, once 4.12.25 clears the 14-day minimumReleaseAge.
   - hono@4.12.25
   # Remove on or after 2026-06-25, once 0.28.1 clears the 14-day minimumReleaseAge.
   - esbuild@0.28.1
   - '@esbuild/*'
+  # Remove on or after 2026-06-29, once 7.28.0 clears the 14-day minimumReleaseAge.
+  - undici@7.28.0


### PR DESCRIPTION
Fixes Dependabot alert #97.

## Vulnerability
- **CVE-2026-9697** / GHSA-vmh5-mc38-953g — **high** severity
- undici `>= 7.23.0 < 7.28.0` bypasses TLS certificate validation via a dropped `requestTls` in the SOCKS5 ProxyAgent
- Pulled in transitively by `miniflare` under `wrangler` / `@cloudflare/vite-plugin`, resolving at **7.24.8**

## Fix
Resolved undici to **7.28.0** (first patched). Since undici is transitive and `miniflare` still pins the vulnerable range, this uses a scoped override:

```yaml
'undici@>=7.23.0 <7.28.0': 7.28.0
```

7.28.0 was published 2026-06-15, inside the 14-day `minimumReleaseAge` window, so it's added to `minimumReleaseAgeExclude` with a dated remove-by note (2026-06-29) matching the existing esbuild/hono pattern.

**Lockfile-only diff** — changes are limited to `pnpm-lock.yaml` and `pnpm-workspace.yaml`. No application code touched.

`pnpm why -r undici` confirms a single resolved version at 7.28.0.