### PR TITLE
Default to current date on reopen

### DIFF
--- a/e2e/features/reopen-date.feature
+++ b/e2e/features/reopen-date.feature
@@ -1,0 +1,8 @@
+Feature: Default to current date on reopen
+
+  Scenario: the dates reset to today when the app is reopened
+    Given I open the home page
+    And I set the start date to "2020-01-15"
+    When I reopen the app
+    Then the start date should be today
+    And the end date should be today

--- a/e2e/steps/reopen-date.steps.ts
+++ b/e2e/steps/reopen-date.steps.ts
@@ -1,0 +1,26 @@
+import { expect } from "@playwright/test";
+import { Given, When, Then } from "./fixtures";
+
+const todayStr = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+Given("I set the start date to {string}", async ({ page }, date: string) => {
+  await page.getByLabel("Start Date").fill(date);
+});
+
+When("I reopen the app", async ({ page }) => {
+  await page.goto("/");
+});
+
+Then("the start date should be today", async ({ page }) => {
+  await expect(page.getByLabel("Start Date")).toHaveValue(todayStr());
+});
+
+Then("the end date should be today", async ({ page }) => {
+  await expect(page.getByLabel("End Date")).toHaveValue(todayStr());
+});

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -45,8 +45,8 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
 
     activity.value = {
       ...activity.value,
-      startTime: activity.value.startTime ?? now,
-      endTime: activity.value.endTime ?? now,
+      startTime: now,
+      endTime: now,
     };
   }, []);
 


### PR DESCRIPTION
## What
When the app is reopened, the start/end dates now default to the current date instead of whatever date was last viewed.

## Why
`Home.tsx` restored `startTime`/`endTime` from localStorage and only filled in `now` when they were null (`?? now`), so reopening showed the stale last-viewed date.

## Change
- `web/routes/Home.tsx`: on mount, always reset `startTime`/`endTime` to the current rounded hour.
- Added `e2e/features/reopen-date.feature` + steps covering the reset-on-reopen behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)