### PR TITLE
Add reset-to-now button near datetime fields

### DIFF
--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -25,6 +25,8 @@ Feature: Home page
     And I click the "Reset to now" button
     Then the start date should be today
     And the end date should be today
+    And the start time should be on the hour
+    And the end time should be on the hour
 
   Scenario: Filling out the form for a group session
     Given I open the home page

--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -22,7 +22,7 @@ Feature: Home page
   Scenario: resetting the datetime fields to today and now
     Given I open the home page
     When I change the start date to "2020-01-01"
-    And I click the "Reset to now" button
+    And I click the "Reset dates to today" button
     Then the start date should be today
     And the end date should be today
     And the start time should be on the hour

--- a/e2e/features/home.feature
+++ b/e2e/features/home.feature
@@ -19,6 +19,13 @@ Feature: Home page
     When I save the activity anyway
     Then I should not see "Activity duration is less than 1 minute"
 
+  Scenario: resetting the datetime fields to today and now
+    Given I open the home page
+    When I change the start date to "2020-01-01"
+    And I click the "Reset to now" button
+    Then the start date should be today
+    And the end date should be today
+
   Scenario: Filling out the form for a group session
     Given I open the home page
     And the therapist is set to "Miss Amanda"

--- a/e2e/steps/home.steps.ts
+++ b/e2e/steps/home.steps.ts
@@ -5,6 +5,26 @@ Then("the page title should contain {string}", async ({ page }, title: string) =
   await expect(page).toHaveTitle(new RegExp(title));
 });
 
+When("I change the start date to {string}", async ({ page }, value: string) => {
+  await page.getByLabel("Start Date").fill(value);
+});
+
+const todayStr = () => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+Then("the start date should be today", async ({ page }) => {
+  await expect(page.getByLabel("Start Date")).toHaveValue(todayStr());
+});
+
+Then("the end date should be today", async ({ page }) => {
+  await expect(page.getByLabel("End Date")).toHaveValue(todayStr());
+});
+
 When("I enter the start time as the end time", async ({ page }) => {
   const startTime = await page.getByLabel("Start Time").inputValue();
   await page.getByLabel("End Time").fill(startTime);

--- a/e2e/steps/home.steps.ts
+++ b/e2e/steps/home.steps.ts
@@ -25,6 +25,14 @@ Then("the end date should be today", async ({ page }) => {
   await expect(page.getByLabel("End Date")).toHaveValue(todayStr());
 });
 
+Then("the start time should be on the hour", async ({ page }) => {
+  await expect(page.getByLabel("Start Time")).toHaveValue(/:00:00$/);
+});
+
+Then("the end time should be on the hour", async ({ page }) => {
+  await expect(page.getByLabel("End Time")).toHaveValue(/:00:00$/);
+});
+
 When("I enter the start time as the end time", async ({ page }) => {
   const startTime = await page.getByLabel("Start Time").inputValue();
   await page.getByLabel("End Time").fill(startTime);

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -314,7 +314,7 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                 activity.value = { ...activity.value, startTime: now, endTime: now };
               }}
             >
-              Reset to now
+              Reset dates to today
             </Button>
 
             <div class="text-center">

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -214,19 +214,6 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
               <CharCounter value={activity.value.description} max={140} />
             </Label>
 
-            <Button
-              type="button"
-              variant="ghost"
-              size="xs"
-              className="self-end text-muted-foreground"
-              onClick={() => {
-                const now = new Date();
-                activity.value = { ...activity.value, startTime: now, endTime: now };
-              }}
-            >
-              Reset to now
-            </Button>
-
             <div class="flex gap-4">
               <Label className="flex-1">
                 Start Date
@@ -316,6 +303,19 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
                 />
               </Label>
             </div>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="self-start text-muted-foreground"
+              onClick={() => {
+                const now = roundDateToHour(new Date());
+                activity.value = { ...activity.value, startTime: now, endTime: now };
+              }}
+            >
+              Reset to now
+            </Button>
 
             <div class="text-center">
               {!activity.value.therapistName && (

--- a/web/routes/Home.tsx
+++ b/web/routes/Home.tsx
@@ -214,6 +214,19 @@ export const Home = ({ database }: { database: IDBDatabase }) => {
               <CharCounter value={activity.value.description} max={140} />
             </Label>
 
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              className="self-end text-muted-foreground"
+              onClick={() => {
+                const now = new Date();
+                activity.value = { ...activity.value, startTime: now, endTime: now };
+              }}
+            >
+              Reset to now
+            </Button>
+
             <div class="flex gap-4">
               <Label className="flex-1">
                 Start Date


### PR DESCRIPTION
Adds a subtle, low-visual-weight button above the start/end date fields on the home form. Clicking it resets `startTime` and `endTime` to today's date and the current time.

- Ghost variant, `xs` size, muted text — secondary action, not primary.
- New Cucumber scenario covers the reset behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)