### PR TITLE
Add group-session prefill link

### DIFF
--- a/e2e/features/group-session.feature
+++ b/e2e/features/group-session.feature
@@ -1,0 +1,23 @@
+Feature: Group session prefill
+
+  Scenario: prefills group name, session type, and campers
+    When I open the group session link for group "Triathlon" with campers "Fred W., Bob F."
+    Then I should see the "Care Clock" heading
+    And the group name should be "Triathlon"
+    And I should see "Fred W., Bob F."
+
+  Scenario: campers not in the stored list can still be unselected
+    When I open the group session link for group "Triathlon" with campers "Fred W., Bob F."
+    Then I should see the "Care Clock" heading
+    When I open the camper selector
+    Then I should see "Fred W."
+    And I should see "Bob F."
+    When I toggle the camper "Bob F."
+    And I click the "Back" button
+    Then I should see "Fred W."
+    And I should not see "Bob F."
+
+  Scenario: temporary campers are not added to the stored camper list
+    When I open the group session link for group "Triathlon" with campers "Fred W., Bob F."
+    Then I should see the "Care Clock" heading
+    And the stored campers should be empty

--- a/e2e/steps/group-session.steps.ts
+++ b/e2e/steps/group-session.steps.ts
@@ -1,0 +1,23 @@
+import { expect } from "@playwright/test";
+import { When, Then } from "./fixtures";
+
+const parseCampers = (list: string): string[] => list.split(",").map((name) => name.trim());
+
+When(
+  "I open the group session link for group {string} with campers {string}",
+  async ({ page }, group: string, list: string) => {
+    const query = [
+      `group=${encodeURIComponent(group)}`,
+      ...parseCampers(list).map((name) => `camper=${encodeURIComponent(name)}`),
+    ].join("&");
+    await page.goto(`/group-session?${query}`);
+  },
+);
+
+When("I toggle the camper {string}", async ({ page }, name: string) => {
+  await page.getByText(name, { exact: true }).click();
+});
+
+Then("the group name should be {string}", async ({ page }, value: string) => {
+  await expect(page.getByLabel("Group")).toHaveValue(value);
+});

--- a/web/App.tsx
+++ b/web/App.tsx
@@ -2,6 +2,7 @@ import { LocationProvider, ErrorBoundary, Router, Route } from "preact-iso";
 
 import { Home } from "./routes/Home";
 import { CamperImport } from "./routes/CamperImport";
+import { GroupSession } from "./routes/GroupSession";
 import { Timer } from "./routes/Timer";
 import { NotFound } from "./routes/404";
 import { Toaster } from "./components/Toaster";
@@ -12,6 +13,7 @@ export const App = ({ database }: { database: IDBDatabase }) => (
       <Router>
         <Route path="/" component={Home} database={database} />
         <Route path="/camper-import" component={CamperImport} database={database} />
+        <Route path="/group-session" component={GroupSession} database={database} />
         <Route path="/timer" component={Timer} database={database} />
         <NotFound default />
       </Router>

--- a/web/components/CampersModal.tsx
+++ b/web/components/CampersModal.tsx
@@ -24,6 +24,13 @@ export const CamperModal = ({
 
   const editMode = useSignal(false);
   const showClearConfirm = useSignal(false);
+
+  // In select mode, also show selected campers that aren't in the stored list (e.g.
+  // off-caseload campers prefilled from a group-session link) so they can be
+  // unselected. Edit mode only manages stored campers.
+  const displayCampers = editMode.value
+    ? campers.value
+    : [...new Set([...campers.value, ...selectedCampers])].sort();
   const onClickClose = () => {
     if (editMode.value) {
       editMode.value = false;
@@ -55,10 +62,10 @@ export const CamperModal = ({
       {editMode.value && <NewCamperForm onAdd={(name) => (campers.value = [...campers.value, name].sort())} />}
 
       <ul class="flex flex-col divide-y-1 divide-secondary/40">
-        {campers.value.length === 0 && !editMode.value && (
+        {displayCampers.length === 0 && !editMode.value && (
           <li class="text-center text-secondary pt-10">Use the edit button on the top right to add a camper</li>
         )}
-        {campers.value.map((camper, i) => (
+        {displayCampers.map((camper, i) => (
           <Camper
             camper={camper}
             editMode={editMode}

--- a/web/data/useActivity.ts
+++ b/web/data/useActivity.ts
@@ -60,7 +60,7 @@ const parseLocalStorageActivity = (activityJSON: string | null): MultiCamperActi
   };
 };
 
-const formatActivityForLocalStorage = (activity: MultiCamperActivity) => {
+export const formatActivityForLocalStorage = (activity: MultiCamperActivity) => {
   return JSON.stringify({
     therapistName: activity.therapistName,
     campers: activity.campers,

--- a/web/routes/GroupSession.tsx
+++ b/web/routes/GroupSession.tsx
@@ -1,0 +1,38 @@
+import { useLocation } from "preact-iso";
+import { useEffect } from "preact/hooks";
+
+import { blankActivity, formatActivityForLocalStorage, useActivity } from "@/data/useActivity";
+
+/**
+ * Consumes a group-session prefill link (e.g. from a QR code) and lands the
+ * therapist directly on a form prefilled for a "Group" session. The campers in
+ * the link are pre-selected but intentionally NOT added to the stored camper
+ * list, so off-caseload campers stay temporary.
+ */
+export const GroupSession = () => {
+  const { url, route } = useLocation();
+  const activity = useActivity();
+
+  useEffect(() => {
+    const search = url.includes("?") ? url.slice(url.indexOf("?")) : "";
+    const params = new URLSearchParams(search);
+    const groupName = params.get("group") ?? "";
+    const campers = params.getAll("camper").map((name) => ({ name, id: null }));
+
+    const prefilled = {
+      ...blankActivity,
+      therapistName: activity.value.therapistName,
+      sessionType: "Group" as const,
+      groupName,
+      campers,
+    };
+
+    activity.value = prefilled;
+    // Persist directly so the write lands before route("/") unmounts us, mirroring
+    // CamperImport. Home reads the activity from localStorage on mount.
+    localStorage.setItem("activity", formatActivityForLocalStorage(prefilled));
+    route("/");
+  }, []);
+
+  return null;
+};


### PR DESCRIPTION
## What

Adds a `/group-session` route that consumes a prefill link (e.g. encoded in a QR code) and lands the therapist directly on a form prefilled for a **Group** session:

- `sessionType` set to `Group`
- `groupName` pre-filled from the `group` query param
- campers pre-selected from repeated `camper` query params

Link shape: `/group-session?group=Triathlon&camper=Fred%20W.&camper=Bob%20F.`

## Off-caseload campers

Campers in the link are pre-selected but **not** added to the stored camper list. The camper selector (`CamperModal`) now renders the union of stored + currently-selected campers in select mode, so a therapist can still **unselect** an off-caseload camper who didn't show up. Unselecting just drops them from the activity; the stored list is never touched. Edit mode still only manages stored campers.

## Scope

Consume-only — the QR image is generated externally from the URL. Landing is direct prefill (overwrites any in-progress activity), matching the agreed scope.

## Notes

- `therapistName` is preserved across the prefill.
- Activity is written straight to localStorage before navigating, mirroring `CamperImport`, so `Home` reads it cleanly on mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)