### PR TITLE
Remove unnecessary CORS middleware

### DIFF
--- a/e2e/features/cors.feature
+++ b/e2e/features/cors.feature
@@ -1,0 +1,5 @@
+Feature: API CORS headers
+
+  Scenario: the API does not advertise CORS access to every origin
+    When I request the activities API from another origin
+    Then the response should not include an Access-Control-Allow-Origin header

--- a/e2e/steps/cors.steps.ts
+++ b/e2e/steps/cors.steps.ts
@@ -1,0 +1,22 @@
+import { expect } from "@playwright/test";
+import type { APIResponse } from "@playwright/test";
+import { When, Then } from "./fixtures";
+
+let response: APIResponse;
+
+// An empty body fails request validation with a 400 before the handler touches
+// the spreadsheet, so this exercises the CORS middleware without external deps.
+When("I request the activities API from another origin", async ({ request }) => {
+  response = await request.fetch("/activities/00000000-0000-0000-0000-000000000000", {
+    method: "PUT",
+    headers: {
+      Origin: "https://evil.example.com",
+      "Content-Type": "application/json",
+    },
+    data: {},
+  });
+});
+
+Then("the response should not include an Access-Control-Allow-Origin header", () => {
+  expect(response.headers()["access-control-allow-origin"]).toBeUndefined();
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 import { fromHono } from "chanfana";
 import { Hono } from "hono";
-import { cors } from "hono/cors";
 
 import { ActivityUpsert } from "./endpoints/activityUpsert";
 import { ActivityDelete } from "./endpoints/activityDelete";
@@ -12,8 +11,6 @@ const app = new Hono();
 const openapi = fromHono(app, {
   docs_url: "/docs",
 });
-
-openapi.use(cors());
 
 // Register OpenAPI endpoints
 openapi.put("/activities/:id", ActivityUpsert);


### PR DESCRIPTION
## What

Removes the `cors()` middleware from the Care Clock Worker (`src/index.ts`).

## Why

CORS was enabled back when the UI (`care-clock.com`) and API (`api.care-clock.com`) lived on separate origins. They're now a single origin — `apiUrl()` resolves against `window.location.origin`, and local dev serves both UI and Worker API on `:8787`. Same-origin requests never trigger CORS, so `cors()` did nothing for the app and only advertised `Access-Control-Allow-Origin: *` to the entire internet.

## Tests

Added an e2e scenario (`e2e/features/cors.feature`) asserting an API response does **not** include an `Access-Control-Allow-Origin` header. Written failing first, then made green by the deletion. Full suite (25) passes — including upsert/delete, which are same-origin and unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)