### PR TITLE
Cap activity description at 25,000 characters

### DIFF
--- a/e2e/features/activity-validation.feature
+++ b/e2e/features/activity-validation.feature
@@ -1,0 +1,5 @@
+Feature: Activity validation
+
+  Scenario: rejects a description longer than 25000 characters
+    When I PUT an activity with a description of 25001 characters
+    Then the response status should be in the 4xx range

--- a/e2e/steps/activity-validation.steps.ts
+++ b/e2e/steps/activity-validation.steps.ts
@@ -1,0 +1,24 @@
+import { expect } from "@playwright/test";
+import { When, Then } from "./fixtures";
+
+// Validation runs before any Google Sheets access, so an over-limit
+// description is rejected without needing real backend credentials.
+let lastStatus: number;
+
+When("I PUT an activity with a description of {int} characters", async ({ request }, length: number) => {
+  const response = await request.put("/activities/11111111-1111-4111-8111-111111111111", {
+    data: {
+      therapistName: "Miss Amanda",
+      camperName: "Alice",
+      sessionType: "Individual",
+      description: "x".repeat(length),
+      startTime: "2026-06-25T10:00:00.000Z",
+    },
+  });
+  lastStatus = response.status();
+});
+
+Then("the response status should be in the 4xx range", async () => {
+  expect(lastStatus).toBeGreaterThanOrEqual(400);
+  expect(lastStatus).toBeLessThan(500);
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export const Activity = z.object({
   sessionType: z.enum(["Individual", "Co-Treat", "Group", "Consult", "Training"]),
   groupName: z.string().nullish(),
   withWho: z.string().nullish(),
-  description: z.string(),
+  description: z.string().max(25000),
   startTime: z.iso.datetime(),
   endTime: z.iso.datetime().nullish(),
 });


### PR DESCRIPTION
Caps the activity `description` field at 25,000 characters, server-side only.

## What
- `src/types.ts`: `description` changed from `z.string()` to `z.string().max(25000)`.
- The PUT `/activities/:id` endpoint already calls `getValidatedData()`, so an over-limit description is rejected automatically.

## Why this works without creds
Validation runs **before** `getSheetFromEnv`, so the rejection happens without touching Google Sheets. The originally-discovered ceiling was 50k; 25k gives headroom.

## Test
Added an API-level e2e (`activity-validation.feature`): PUT a 25,001-char description → asserts a 4xx. Watched it fail (204) before the change, pass (400) after. Full suite: 25/25 green.

Client does not enforce or display anything yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)